### PR TITLE
Supported GHC 8.8.1

### DIFF
--- a/Data/FMList.hs
+++ b/Data/FMList.hs
@@ -97,6 +97,7 @@ import Data.Semigroup (Semigroup((<>)))
 import Data.Foldable (Foldable, foldMap, foldr, toList)
 import Data.Traversable (Traversable, traverse)
 import Control.Monad
+import Control.Monad.Fail as MF
 import Control.Applicative
 
 -- | 'FMList' is a 'foldMap' function wrapped up in a newtype.
@@ -293,7 +294,9 @@ instance Monad FMList where
   return     = one
   m >>= g    = transform (\f -> foldMap f . g) m
   m >> k     = transform (\f -> const (foldMap f k)) m
-  fail _     = nil
+
+instance MF.MonadFail FMList where
+  fail _ = nil
 
 instance Applicative FMList where
   pure       = one

--- a/fmlist.cabal
+++ b/fmlist.cabal
@@ -21,7 +21,10 @@ cabal-version:       >= 1.10
 Library
   exposed-modules:     Data.FMList
   build-depends:       base >= 3 && < 5
+  if impl(ghc < 8.0)
+    build-depends: fail
   default-language:    Haskell98
+
 
 source-repository head
   type:     git


### PR DESCRIPTION
GHC 8.8.1-alpha2 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2019-June/017777.html). In this PR I fixed the compilation with this version of GHC. All the changes were required by the MonadFail proposal (see [Library Changes](https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.8#base-41300) in GHC 8.8.1).

Blocking https://github.com/agda/agda/issues/3725.