### PR TITLE
Fix type error on GHC 9

### DIFF
--- a/Data/FMList.hs
+++ b/Data/FMList.hs
@@ -285,7 +285,7 @@ instance Functor FMList where
   a <$ l     = transform (\f -> const (f a)) l
 
 instance Foldable FMList where
-  foldMap    = flip unFM
+  foldMap m f = unFM f m
 
 instance Traversable FMList where
   traverse f = foldMapA (fmap one . f)


### PR DESCRIPTION
Before this change, (soon to be released) GHC 9 was throwing this error:

```

Data/FMList.hs:289:18: error:
    • Couldn't match type: forall m1. Monoid m1 => (a -> m1) -> m1
                     with: (a -> m) -> m
      Expected: FMList a -> (a -> m) -> m
        Actual: FMList a -> forall m. Monoid m => (a -> m) -> m
    • In the first argument of ‘flip’, namely ‘unFM’
      In the expression: flip unFM
      In an equation for ‘foldMap’: foldMap = flip unFM
    • Relevant bindings include
        foldMap :: (a -> m) -> FMList a -> m
          (bound at Data/FMList.hs:289:3)
    |
289 |   foldMap = flip unFM
    |                  ^^^^
```

I think it was because of the "simplified subsumption" work[1].

[1]: https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#simplified-subsumption

It seems to be happy after this change.