### PR TITLE
Fix warnings about non-canonical instances

### DIFF
--- a/fmlist.cabal
+++ b/fmlist.cabal
@@ -36,8 +36,12 @@ Library
   exposed-modules:     Data.FMList
   build-depends:       base >= 3 && < 5
   if impl(ghc < 8.0)
-    build-depends: fail
+    build-depends:     fail
   default-language:    Haskell98
+
+  ghc-options:         -Wall
+  if impl(ghc >= 8.0)
+    ghc-options:       -Wcompat
 
 
 source-repository head


### PR DESCRIPTION
Fix warnings about non-canonical instances, using `#if MIN_VERSION_base(4,9.0)` (this is GHC 8.0).

Also, switch on `-Wall` and `-Wcompat` in the cabal file.